### PR TITLE
Remove multiline so it works on podman compose

### DIFF
--- a/podman-compose/podman-compose.yml
+++ b/podman-compose/podman-compose.yml
@@ -19,11 +19,7 @@ services:
         LOG_DIR: /var/lib/kafka
       command: >
         bash -c "
-          /opt/kafka/bin/kafka-storage.sh format \
-            --config /opt/kafka/config/server.properties \
-            --cluster-id 'ciVofVj9T9aU1a3S-n3CBA' \
-            --ignore-formatted ;
-          /opt/kafka/bin/kafka-server-start.sh /opt/kafka/config/server.properties
+          /opt/kafka/bin/kafka-storage.sh format --config /opt/kafka/config/server.properties --cluster-id 'ciVofVj9T9aU1a3S-n3CBA' --ignore-formatted ; /opt/kafka/bin/kafka-server-start.sh /opt/kafka/config/server.properties
         " 
       healthcheck:
         test: ["CMD-SHELL", "/opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list"]


### PR DESCRIPTION
podman compose doesn't recognize the multiline command in the kafka component